### PR TITLE
Fix mapbox 404 error after refactor

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,10 +7,10 @@ import { componentTagger } from "lovable-tagger";
 export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
-    port: 8080,
+    port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: 'http://localhost:8080',
         changeOrigin: true,
         secure: false,
       }


### PR DESCRIPTION
Update Vite configuration to resolve Mapbox configuration 404 errors.

The frontend dev server's port was conflicting with the backend, and its API proxy was pointing to the wrong backend port, leading to 404s for Mapbox config requests. This PR adjusts the frontend dev server port and corrects the API proxy target.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ce4e551-31dc-497c-ad72-9cad75b1613c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ce4e551-31dc-497c-ad72-9cad75b1613c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>